### PR TITLE
Fix level of headers between svnwiki and md

### DIFF
--- a/semantics2svn-impl.scm
+++ b/semantics2svn-impl.scm
@@ -296,7 +296,7 @@
   (define (svn-transform-class-definition d methods)
     (let ((used-methods (svn-find-class-methods (svn-aspect->string 'name d)
 						methods)))
-      (string-append "=== Class "
+      (string-append "==== Class "
 		     (svn-aspect->string 'name d)
 		     "\n<class>"
 		     (svn-aspect->string 'name d)
@@ -336,7 +336,7 @@
 				       (filter is-method?
 					       (alist-ref 'body (cdr d))))))
       (string-append
-       "== Module "
+       "=== Module "
        (svn-aspect->string 'name d)
        "\n"
        (svn-transform-comment d)


### PR DESCRIPTION
Hi,

I noticed that as is the semantic is slightly different between svnwiki and markdown because the level of header attributed to modules and classes was not offset by one like it is when the header is parsed from a comment.

For example, this file:

```scheme
;;; # Bug repro
;;;

;;;
;;; Is the foo module part of bug repro section?
;;;
(module foo *

  ;;; Bar the baz
  (define (bar baz)
    #f)

  ;;; Class Fizz
  (define-class <fizz> ()
    (buzz))
  )
```

Will produce these outputs:

```markdown
# Bug repro

## [module] foo

Is the foo module part of bug repro section?
  
#### [procedure] `(bar BAZ)`
  
Bar the baz  


### [class] `<fizz>`  
slot: `buzz`


Class Fizz  


```

```
== Bug repro

== Module foo

Is the foo module part of bug repro section?

<procedure>(bar BAZ)</procedure>

Bar the baz


=== Class <fizz>
<class><fizz></class>


; slot : {{buzz}}


Class Fizz


```

As you can see, in one case `Module foo` is part of the top section, while it is not in the other.

Since `== Module` and `=== Class` are hardcoded it is a very simple fix, which is why I did not start with an issue.

The new behavior I propose would produce this:


```
== Bug repro

=== Module foo

Is the foo module part of bug repro section?

<procedure>(bar BAZ)</procedure>

Bar the baz


==== Class <fizz>
<class><fizz></class>


; slot : {{buzz}}


Class Fizz


```